### PR TITLE
WIP Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: trusty
+dist: xenial
 compiler: gcc
 language: cpp
 sudo: false


### PR DESCRIPTION
According to #11, 
> Travis CI build fails because the included cmake version is older then the minimum required by Urho3D.

Looking at the build logs, it appears that the minimum version of cmake
required is 3.2.3. According to https://launchpad.net/ubuntu/+source/cmake
xenial provides version 3.5.1